### PR TITLE
Add shield badges to backport

### DIFF
--- a/backport/createStatusComment.test.ts
+++ b/backport/createStatusComment.test.ts
@@ -7,86 +7,85 @@ const BACKPORT_TEMPLATE = 'node scripts/backport --pr %pullNumber%';
 describe('createStatusComment', () => {
   describe('getCommentFromResponse', () => {
     it('should create a message for all successful backports', async () => {
-      const comment = getCommentFromResponse(1, BACKPORT_TEMPLATE, {
-        results: [
-          {
-            success: true,
-            targetBranch: '7.x',
-            pullRequestUrl: 'https://github.com/elastic/kibana/pull/2',
-          },
-          {
-            success: true,
-            targetBranch: '7.10',
-            pullRequestUrl: 'https://github.com/elastic/kibana/pull/3',
-          },
-        ],
-        success: true,
-      } as BackportResponse);
+      const comment = getCommentFromResponse(
+        1,
+        BACKPORT_TEMPLATE,
+        {
+          results: [
+            {
+              success: true,
+              targetBranch: '7.x',
+              pullRequestUrl: 'https://github.com/elastic/kibana/pull/2',
+            },
+            {
+              success: true,
+              targetBranch: '7.10',
+              pullRequestUrl: 'https://github.com/elastic/kibana/pull/3',
+            },
+          ],
+          success: true,
+        } as BackportResponse,
+        'elastic',
+        'kibana',
+      );
       expect(comment).to.eql(
-        `## 💚 Backport successful
-
-✅ [7.x](https://github.com/elastic/kibana/pull/2) / https://github.com/elastic/kibana/pull/2
-✅ [7.10](https://github.com/elastic/kibana/pull/3) / https://github.com/elastic/kibana/pull/3
-
-The backport PRs will be merged automatically after passing CI.`,
+        '## 💚 Backport successful\n\n| Status | Branch | Result |\n|:------:|:------:|:------:|| ✅ |  [7.x](https://github.com/elastic/kibana/pull/2)  | [<img src="https://img.shields.io/github/pulls/detail/state/elastic/kibana/2">](https://github.com/elastic/kibana/pull/2) |\n| ✅ |  [7.10](https://github.com/elastic/kibana/pull/3)  | [<img src="https://img.shields.io/github/pulls/detail/state/elastic/kibana/3">](https://github.com/elastic/kibana/pull/3) |\n\nThe backport PRs will be merged automatically after passing CI.',
       );
     });
 
     it('should create a message for a mix of successful and failed backports', async () => {
-      const comment = getCommentFromResponse(1, BACKPORT_TEMPLATE, {
-        results: [
-          {
-            success: true,
-            targetBranch: '7.x',
-            pullRequestUrl: 'https://github.com/elastic/kibana/pull/2',
-          },
-          {
-            success: false,
-            targetBranch: '7.10',
-            errorMessage: 'There was a merge conflict',
-          },
-        ],
-        success: false,
-      } as BackportResponse);
+      const comment = getCommentFromResponse(
+        1,
+        BACKPORT_TEMPLATE,
+        {
+          results: [
+            {
+              success: true,
+              targetBranch: '7.x',
+              pullRequestUrl: 'https://github.com/elastic/kibana/pull/2',
+            },
+            {
+              success: false,
+              targetBranch: '7.10',
+              errorMessage: 'There was a merge conflict',
+            },
+          ],
+          success: false,
+        } as BackportResponse,
+        'elastic',
+        'kibana',
+      );
 
       expect(comment).to.eql(
-        `## 💔 Backport failed
-
-✅ [7.x](https://github.com/elastic/kibana/pull/2) / https://github.com/elastic/kibana/pull/2
-❌ 7.10: There was a merge conflict
-
-Successful backport PRs will be merged automatically after passing CI.
-
-To backport manually run:
-\`node scripts/backport --pr 1\``,
+        '## 💔 Backport failed\n\n| Status | Branch | Result |\n|:------:|:------:|:------:|| ✅ |  [7.x](https://github.com/elastic/kibana/pull/2)  | [<img src="https://img.shields.io/github/pulls/detail/state/elastic/kibana/2">](https://github.com/elastic/kibana/pull/2) |\n| ❌ |  7.10  | There was a merge conflict |\n\nSuccessful backport PRs will be merged automatically after passing CI.\n\nTo backport manually run:\n`node scripts/backport --pr 1`',
       );
     });
 
     it('should create a message for a all failed backports', async () => {
-      const comment = getCommentFromResponse(1, BACKPORT_TEMPLATE, {
-        results: [
-          {
-            success: false,
-            targetBranch: '7.x',
-            errorMessage: 'There was a merge conflict',
-          },
-          {
-            success: false,
-            targetBranch: '7.10',
-            errorMessage: 'There was a merge conflict',
-          },
-        ],
-        success: false,
-      } as BackportResponse);
+      const comment = getCommentFromResponse(
+        1,
+        BACKPORT_TEMPLATE,
+        {
+          results: [
+            {
+              success: false,
+              targetBranch: '7.x',
+              errorMessage: 'There was a merge conflict',
+            },
+            {
+              success: false,
+              targetBranch: '7.10',
+              errorMessage: 'There was a merge conflict',
+            },
+          ],
+          success: false,
+        } as BackportResponse,
+        'elastic',
+        'kibana',
+      );
 
       expect(comment).to.eql(
-        `## 💔 Backport failed
-
-❌ 7.x: There was a merge conflict
-❌ 7.10: There was a merge conflict
-
-To backport manually run:
-\`node scripts/backport --pr 1\``,
+        '## 💔 Backport failed\n\n| Status | Branch | Result |\n|:------:|:------:|:------:|| ❌ |  7.x  | There was a merge conflict |\n| ❌ |  7.10  | There was a merge conflict |\n\nTo backport manually run:\n`node scripts/backport --pr 1`',
       );
     });
   });


### PR DESCRIPTION
This PR adds shields.io badges which makes it possible to see the status of the backport pull request. This will indicate whether the PR is open, closed or merged.

![image](https://user-images.githubusercontent.com/209966/113857578-f96b7f80-97a2-11eb-9452-dadff4438cb0.png)
