### PR TITLE
Use the provided token to read `.backportrc.json`

### DIFF
--- a/backport/index.js
+++ b/backport/index.js
@@ -7,7 +7,7 @@ const exec_1 = require("@actions/exec");
 const github_1 = require("@actions/github");
 const backport_1 = require("backport");
 const createStatusComment_1 = require("./createStatusComment");
-exports.getConfig = async (repoOwner, repoName, branch, accessToken) => {
+const getConfig = async (repoOwner, repoName, branch, accessToken) => {
     const url = `https://raw.githubusercontent.com/${repoOwner}/${repoName}/${branch}/.backportrc.json`;
     const config = {
         method: 'get',

--- a/backport/index.js
+++ b/backport/index.js
@@ -7,9 +7,14 @@ const exec_1 = require("@actions/exec");
 const github_1 = require("@actions/github");
 const backport_1 = require("backport");
 const createStatusComment_1 = require("./createStatusComment");
-const getConfig = async (repoOwner, repoName, branch) => {
+exports.getConfig = async (repoOwner, repoName, branch, accessToken) => {
     const url = `https://raw.githubusercontent.com/${repoOwner}/${repoName}/${branch}/.backportrc.json`;
-    const resp = await axios_1.default.get(url);
+    const config = {
+        method: 'get',
+        url: url,
+        headers: { Authorization: `token ${accessToken}` },
+    };
+    const resp = await axios_1.default(config);
     return resp.data;
 };
 exports.getConfig = getConfig;
@@ -33,7 +38,7 @@ async function backport() {
     const backportCommandTemplate = core.getInput('manual_backport_command_template', { required: true });
     await exec_1.exec(`git config --global user.name "${commitUser}"`);
     await exec_1.exec(`git config --global user.email "${commitEmail}"`);
-    const config = await exports.getConfig(repo.owner, repo.repo, branch);
+    const config = await exports.getConfig(repo.owner, repo.repo, branch, accessToken);
     const backportResponse = await backport_1.run({
         ...config,
         accessToken,

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -1,13 +1,18 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';
 import { context } from '@actions/github';
 import { run, ConfigOptions } from 'backport';
 import createStatusComment from './createStatusComment';
 
-export const getConfig = async (repoOwner: string, repoName: string, branch: string) => {
+export const getConfig = async (repoOwner: string, repoName: string, branch: string, accessToken: string) => {
   const url = `https://raw.githubusercontent.com/${repoOwner}/${repoName}/${branch}/.backportrc.json`;
-  const resp = await axios.get(url);
+  const config: AxiosRequestConfig = {
+    method: 'get',
+    url: url,
+    headers: { Authorization: `token ${accessToken}` },
+  };
+  const resp = await axios(config);
   return resp.data as ConfigOptions;
 };
 
@@ -38,7 +43,7 @@ async function backport() {
   await exec(`git config --global user.name "${commitUser}"`);
   await exec(`git config --global user.email "${commitEmail}"`);
 
-  const config = await getConfig(repo.owner, repo.repo, branch);
+  const config = await getConfig(repo.owner, repo.repo, branch, accessToken);
 
   const backportResponse = await run({
     ...config,


### PR DESCRIPTION
Our repo is private so we need to pass the GH token when requesting it. I don't think that will be a problem for public repositories to have that extra header on public pages.