### PR TITLE
Allow for customization or target pull request labels

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: ''
     required: false
     default: 'node scripts/backport --pr %pullNumber%'
+  target_pr_labels:
+    description: 'Comma-separated list of additional labels to add to backport pull request'
+    required: false
+    default: 'backport'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/backport/index.js
+++ b/backport/index.js
@@ -36,7 +36,10 @@ async function backport() {
     const autoMerge = core.getInput('auto_merge', { required: true }) === 'true';
     const autoMergeMethod = core.getInput('auto_merge_method', { required: true });
     const backportCommandTemplate = core.getInput('manual_backport_command_template', { required: true });
-    const targetPRLabels = core.getInput('target_pr_labels', { required: true }).split(',');
+    const targetPRLabels = core
+        .getInput('target_pr_labels', { required: true })
+        .split(',')
+        .map((label) => label.trim());
     await exec_1.exec(`git config --global user.name "${commitUser}"`);
     await exec_1.exec(`git config --global user.email "${commitEmail}"`);
     const config = await exports.getConfig(repo.owner, repo.repo, branch, accessToken);

--- a/backport/index.js
+++ b/backport/index.js
@@ -36,6 +36,7 @@ async function backport() {
     const autoMerge = core.getInput('auto_merge', { required: true }) === 'true';
     const autoMergeMethod = core.getInput('auto_merge_method', { required: true });
     const backportCommandTemplate = core.getInput('manual_backport_command_template', { required: true });
+    const targetPRLabels = core.getInput('target_pr_labels', { required: true }).split(',');
     await exec_1.exec(`git config --global user.name "${commitUser}"`);
     await exec_1.exec(`git config --global user.email "${commitEmail}"`);
     const config = await exports.getConfig(repo.owner, repo.repo, branch, accessToken);
@@ -46,7 +47,7 @@ async function backport() {
         username: commitUser,
         ci: true,
         pullNumber: pullRequest.number,
-        labels: ['backport'],
+        targetPRLabels: targetPRLabels,
         assignees: [owner],
         autoMerge: autoMerge,
         autoMergeMethod: autoMergeMethod,

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -39,6 +39,7 @@ async function backport() {
   const autoMerge = core.getInput('auto_merge', { required: true }) === 'true';
   const autoMergeMethod = core.getInput('auto_merge_method', { required: true });
   const backportCommandTemplate = core.getInput('manual_backport_command_template', { required: true });
+  const targetPRLabels = core.getInput('target_pr_labels', { required: true }).split(',');
 
   await exec(`git config --global user.name "${commitUser}"`);
   await exec(`git config --global user.email "${commitEmail}"`);
@@ -52,7 +53,7 @@ async function backport() {
     username: commitUser,
     ci: true,
     pullNumber: pullRequest.number,
-    labels: ['backport'],
+    targetPRLabels: targetPRLabels,
     assignees: [owner],
     autoMerge: autoMerge,
     autoMergeMethod: autoMergeMethod,

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -39,7 +39,10 @@ async function backport() {
   const autoMerge = core.getInput('auto_merge', { required: true }) === 'true';
   const autoMergeMethod = core.getInput('auto_merge_method', { required: true });
   const backportCommandTemplate = core.getInput('manual_backport_command_template', { required: true });
-  const targetPRLabels = core.getInput('target_pr_labels', { required: true }).split(',');
+  const targetPRLabels = core
+    .getInput('target_pr_labels', { required: true })
+    .split(',')
+    .map((label) => label.trim());
 
   await exec(`git config --global user.name "${commitUser}"`);
   await exec(`git config --global user.email "${commitEmail}"`);


### PR DESCRIPTION
Add a new input option to the GitHub action allowing for the user to specify the labels to be added to the target pull request. For backward-compatibility this option is not required, and defaults to the original value of `['backport']`.