### PR TITLE
Add example usage to backport readme

### DIFF
--- a/backport/README.md
+++ b/backport/README.md
@@ -1,3 +1,47 @@
 # backport action
 
+Example usage:
+
+```yml
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - labeled
+      - closed
+
+jobs:
+  backport:
+    name: Backport PR
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+        || (github.event.action == 'closed')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'elastic/kibana-github-actions'
+          ref: main
+          path: ./actions
+
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      - name: Run Backport
+        uses: ./actions/backport
+        with:
+          github_token: ${{secrets.KIBANAMACHINE_TOKEN}}
+          commit_user: <YOUR_USERNAME>
+          commit_email: <YOUR_EMAIL>
+          auto_merge: 'true'
+          auto_merge_method: 'squash'
+          manual_backport_command_template: 'node scripts/backport --pr %pullNumber%'
+```
+
 Borrows heavily from https://github.com/sqren/backport-github-action


### PR DESCRIPTION
I want to deprecated https://github.com/sqren/backport-github-action and want to refer people to use the backport action in this repo.

There are currently a lot of users of the `backport` tool outside of Elastic, and many of them could benefit from this action.

I propose to add an example workflow to make it easier for people to get started with the action.