### PR TITLE
Update backport:prev-minor to backport to all previousMinor versions

### DIFF
--- a/on-merge/backportTargets.js
+++ b/on-merge/backportTargets.js
@@ -13,16 +13,10 @@ function resolveTargets(versions, labelsOriginal) {
     const targets = new Set();
     const labels = labelsOriginal.map((label) => label.toLowerCase());
     if (labels.includes('backport:prev-minor')) {
-        targets.add(versions.previousMinor.branch);
-    }
-    if (labels.includes('backport:current-major')) {
-        targets.add(versions.previousMinor.branch);
-        versions.others
-            .filter((version) => version.currentMajor)
-            .forEach((version) => targets.add(version.branch));
+        versions.previousMinor.forEach((version) => targets.add(version.branch));
     }
     if (labels.includes('backport:all-open') || labels.includes('backport:prev-major')) {
-        targets.add(versions.previousMinor.branch);
+        versions.previousMinor.forEach((version) => targets.add(version.branch));
         targets.add(versions.previousMajor.branch);
         versions.others.forEach((version) => targets.add(version.branch));
     }

--- a/on-merge/backportTargets.test.ts
+++ b/on-merge/backportTargets.test.ts
@@ -8,19 +8,22 @@ describe('backportTargets', () => {
   beforeEach(() => {
     mockVersions = {
       currentMinor: { branch: 'main', version: '8.5.0', currentMajor: true, currentMinor: true },
-      previousMinor: { branch: '8.4', version: '8.4.1', currentMajor: true, previousMinor: true },
+      previousMinor: [
+        { branch: '8.4', version: '8.4.1', currentMajor: true, previousMinor: true },
+        { branch: '8.3', version: '8.3.5', currentMajor: true, previousMinor: true },
+      ],
       previousMajor: {
         branch: '7.17',
         version: '7.17.1',
         previousMajor: true,
       },
-      others: [{ branch: '8.3', version: '8.3.15', currentMajor: true }],
+      others: [{ branch: '8.2', version: '8.2.15', currentMajor: true }],
       all: [],
     };
 
     mockVersions.all = [
       mockVersions.currentMinor,
-      mockVersions.previousMinor,
+      ...mockVersions.previousMinor,
       mockVersions.previousMajor,
       ...mockVersions.others,
     ];
@@ -34,27 +37,22 @@ describe('backportTargets', () => {
 
     it('should resolve prev-minor', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-minor']);
-      expect(branches).to.eql(['8.4']);
-    });
-
-    it('should resolve current-major', () => {
-      const branches = resolveTargets(mockVersions, ['backport:current-major']);
       expect(branches).to.eql(['8.3', '8.4']);
     });
 
     it('should resolve prev-major and add all branches', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-major']);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '8.2', '8.3', '8.4']);
     });
 
     it('should resolve prev-MAJOR and add all branches', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-MAJOR']);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '8.2', '8.3', '8.4']);
     });
 
     it('should resolve all-open and add all branches', () => {
       const branches = resolveTargets(mockVersions, ['backport:all-open']);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '8.2', '8.3', '8.4']);
     });
 
     it('should resolve hard-coded version labels', () => {
@@ -64,12 +62,12 @@ describe('backportTargets', () => {
 
     it('should resolve fill in gaps from hard-coded version labels', () => {
       const branches = resolveTargets(mockVersions, ['v7.16.0']);
-      expect(branches).to.eql(['7.16', '7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.16', '7.17', '8.2', '8.3', '8.4']);
     });
 
     it('should resolve hard-coded version labels and target labels', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-major', 'v8.5.0', 'v8.4.1', 'v7.17.1']);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '8.2', '8.3', '8.4']);
     });
 
     it('should resolve multiple labels for same branch and not duplicate', () => {
@@ -80,7 +78,7 @@ describe('backportTargets', () => {
         'v8.4.1',
         'v7.17.1',
       ]);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '8.2', '8.3', '8.4']);
     });
   });
 });

--- a/on-merge/backportTargets.ts
+++ b/on-merge/backportTargets.ts
@@ -14,20 +14,12 @@ export function resolveTargets(versions: VersionsParsed, labelsOriginal: string[
   const targets = new Set<string>();
 
   const labels = labelsOriginal.map((label) => label.toLowerCase());
-
   if (labels.includes('backport:prev-minor')) {
-    targets.add(versions.previousMinor.branch);
-  }
-
-  if (labels.includes('backport:current-major')) {
-    targets.add(versions.previousMinor.branch);
-    versions.others
-      .filter((version) => version.currentMajor)
-      .forEach((version) => targets.add(version.branch));
+    versions.previousMinor.forEach((version) => targets.add(version.branch));
   }
 
   if (labels.includes('backport:all-open') || labels.includes('backport:prev-major')) {
-    targets.add(versions.previousMinor.branch);
+    versions.previousMinor.forEach((version) => targets.add(version.branch));
     targets.add(versions.previousMajor.branch);
     versions.others.forEach((version) => targets.add(version.branch));
   }

--- a/on-merge/versions.js
+++ b/on-merge/versions.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseVersions = void 0;
 function parseVersions(versions) {
     const currentMinor = versions.versions.find((version) => version.currentMinor);
-    const previousMinor = versions.versions.find((version) => version.previousMinor);
+    const previousMinor = versions.versions.filter((version) => version.previousMinor);
     const previousMajor = versions.versions.find((version) => version.previousMajor);
     if (!currentMinor) {
         throw new Error('versions.json is missing current minor version information');

--- a/on-merge/versions.ts
+++ b/on-merge/versions.ts
@@ -18,7 +18,7 @@ export interface VersionBranch {
 
 export interface VersionsParsed {
   currentMinor: Version;
-  previousMinor: Version;
+  previousMinor: Version[];
   previousMajor: Version;
   others: Version[];
   all: Version[];
@@ -26,7 +26,7 @@ export interface VersionsParsed {
 
 export function parseVersions(versions: Versions): VersionsParsed {
   const currentMinor = versions.versions.find((version) => version.currentMinor);
-  const previousMinor = versions.versions.find((version) => version.previousMinor);
+  const previousMinor = versions.versions.filter((version) => version.previousMinor);
   const previousMajor = versions.versions.find((version) => version.previousMajor);
 
   if (!currentMinor) {


### PR DESCRIPTION
We want to change the behavior of `release_note:fix` backports to go back to all minor versions.  There's two options:

1) Leave `backport:prev-minor` as is and advocate for using `backport:current-major`.  This label never made it to the Kibana repository but it is supported.
2) Update `backport:prev-minor` to backport to all minor versions.  Update `backport:all-open` to backport to all minor versions.  Remove `backport:current-major`. 


I took the second approach here.  It's slightly less semantic (may no longer be a single version) but will see immediate adoption.  I don't see a use case for backporting to a single minor version when multiple are available.