### PR TITLE
Update backport:version to only backport to specified versions

### DIFF
--- a/on-merge/backportTargets.js
+++ b/on-merge/backportTargets.js
@@ -42,8 +42,10 @@ function resolveTargets(versions, labelsOriginal) {
         // if the hard-coded version is the same minor as the current minor, we should skip it, because it's `main`
         if (branch !== currentMinor) {
             targets.add(branch);
-            // Fill in gaps, e.g. if `v8.1.0` is specified, add everything that is currently open between 8.1 and <main>
-            getBranchesAfter(versions, version).forEach((branch) => targets.add(branch));
+            if (!labels.includes('backport:version')) {
+                // Fill in gaps, e.g. if `v8.1.0` is specified, add everything that is currently open between 8.1 and <main>
+                getBranchesAfter(versions, version).forEach((branch) => targets.add(branch));
+            }
         }
     });
     return [...targets].sort();

--- a/on-merge/backportTargets.test.ts
+++ b/on-merge/backportTargets.test.ts
@@ -63,7 +63,7 @@ describe('backportTargets', () => {
     });
 
     it('should not fill in gaps from hard-coded version labels when using backport:version', () => {
-      const branches = resolveTargets(mockVersions, ['backport:version', 'v7.15.0', "v8.4.5"]);
+      const branches = resolveTargets(mockVersions, ['backport:version', 'v7.15.0', 'v8.4.5']);
       expect(branches).to.eql(['7.15', '8.4']);
     });
 

--- a/on-merge/backportTargets.test.ts
+++ b/on-merge/backportTargets.test.ts
@@ -62,6 +62,11 @@ describe('backportTargets', () => {
       expect(branches).to.eql(['7.16', '7.17', '8.3', '8.4']);
     });
 
+    it('should not fill in gaps from hard-coded version labels when using backport:version', () => {
+      const branches = resolveTargets(mockVersions, ['backport:version', 'v7.15.0', "v8.4.5"]);
+      expect(branches).to.eql(['7.15', '8.4']);
+    });
+
     it('should resolve hard-coded version labels and target labels', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-major', 'v8.5.0', 'v8.4.1', 'v7.17.1']);
       expect(branches).to.eql(['7.17', '8.3', '8.4']);

--- a/on-merge/backportTargets.ts
+++ b/on-merge/backportTargets.ts
@@ -55,8 +55,10 @@ export function resolveTargets(versions: VersionsParsed, labelsOriginal: string[
       if (branch !== currentMinor) {
         targets.add(branch);
 
-        // Fill in gaps, e.g. if `v8.1.0` is specified, add everything that is currently open between 8.1 and <main>
-        getBranchesAfter(versions, version).forEach((branch) => targets.add(branch));
+        if (!labels.includes('backport:version')) {
+          // Fill in gaps, e.g. if `v8.1.0` is specified, add everything that is currently open between 8.1 and <main>
+          getBranchesAfter(versions, version).forEach((branch) => targets.add(branch));
+        }
       }
     });
 


### PR DESCRIPTION
Previously it would fill in all supported versions between the specified version and the current version.