### PR TITLE
[on-merge] Fix null pull request body

### DIFF
--- a/on-merge/util.js
+++ b/on-merge/util.js
@@ -19,7 +19,7 @@ async function getPrPackageVersion(github, repoOwner, repoName, ref) {
 }
 exports.getPrPackageVersion = getPrPackageVersion;
 function getPrBackportData(prBody) {
-    const prDataMatch = prBody.match(/<!--BACKPORT (.*?) BACKPORT-->/s);
+    const prDataMatch = prBody === null || prBody === void 0 ? void 0 : prBody.match(/<!--BACKPORT (.*?) BACKPORT-->/s);
     if (prDataMatch === null || prDataMatch === void 0 ? void 0 : prDataMatch[1]) {
         const prDataJson = prDataMatch[1];
         const prData = JSON.parse(prDataJson);

--- a/on-merge/util.test.ts
+++ b/on-merge/util.test.ts
@@ -7,6 +7,11 @@ describe('util', () => {
       expect(getPrBackportData('')).to.eql(null);
     });
 
+    it('should return null when body is empty', () => {
+      expect(getPrBackportData(null)).to.eql(null);
+      expect(getPrBackportData(undefined)).to.eql(null);
+    });
+
     it('should parse backport data from body', () => {
       const body = `
       body

--- a/on-merge/util.ts
+++ b/on-merge/util.ts
@@ -22,8 +22,8 @@ export async function getPrPackageVersion(
   return version;
 }
 
-export function getPrBackportData(prBody: string) {
-  const prDataMatch = prBody.match(/<!--BACKPORT (.*?) BACKPORT-->/s);
+export function getPrBackportData(prBody: string | undefined | null) {
+  const prDataMatch = prBody?.match(/<!--BACKPORT (.*?) BACKPORT-->/s);
   if (prDataMatch?.[1]) {
     const prDataJson = prDataMatch[1];
     const prData: Commit[] = JSON.parse(prDataJson);


### PR DESCRIPTION
Pull requests with an empty description return null from the GitHub API. This is causing an uncaught error.

https://github.com/elastic/kibana/actions/runs/10384063022/job/28750253373