### PR TITLE
[backport] Fix branch selection

### DIFF
--- a/on-merge/backportTargets.js
+++ b/on-merge/backportTargets.js
@@ -16,21 +16,19 @@ function resolveTargets(versions, labelsOriginal) {
         targets.add(versions.previousMinor.branch);
     }
     if (labels.includes('backport:prev-major')) {
-        targets.add(versions.previousMajor.branch);
-        versions.others
+        versions.all
             .filter((version) => version.previousMajor)
             .forEach((version) => targets.add(version.branch));
     }
     if (labels.includes('backport:current-major')) {
-        targets.add(versions.previousMinor.branch);
-        versions.others
-            .filter((version) => version.currentMajor)
+        versions.all
+            .filter((version) => version.currentMajor && version.branch !== 'main')
             .forEach((version) => targets.add(version.branch));
     }
     if (labels.includes('backport:all-open')) {
-        targets.add(versions.previousMinor.branch);
-        targets.add(versions.previousMajor.branch);
-        versions.others.forEach((version) => targets.add(version.branch));
+        versions.all
+            .filter((version) => version.branch !== 'main')
+            .forEach((version) => targets.add(version.branch));
     }
     labels
         .filter((label) => label.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/))

--- a/on-merge/backportTargets.js
+++ b/on-merge/backportTargets.js
@@ -16,9 +16,7 @@ function resolveTargets(versions, labelsOriginal) {
         targets.add(versions.previousMinor.branch);
     }
     if (labels.includes('backport:prev-major')) {
-        versions.all
-            .filter((version) => version.previousMajor)
-            .forEach((version) => targets.add(version.branch));
+        versions.all.filter((version) => version.previousMajor).forEach((version) => targets.add(version.branch));
     }
     if (labels.includes('backport:current-major')) {
         versions.all

--- a/on-merge/backportTargets.test.ts
+++ b/on-merge/backportTargets.test.ts
@@ -14,7 +14,6 @@ describe('backportTargets', () => {
         version: '7.17.1',
         previousMajor: true,
       },
-      others: [{ branch: '8.3', version: '8.3.15', currentMajor: true }],
       all: [],
     };
 
@@ -22,7 +21,8 @@ describe('backportTargets', () => {
       mockVersions.currentMinor,
       mockVersions.previousMinor,
       mockVersions.previousMajor,
-      ...mockVersions.others,
+      { branch: '8.3', version: '8.3.15', currentMajor: true },
+      { branch: '7.x', version: '7.17.2', previousMajor: true }
     ];
   });
 
@@ -44,12 +44,12 @@ describe('backportTargets', () => {
 
     it('should resolve prev-major', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-major']);
-      expect(branches).to.eql(['7.17']);
+      expect(branches).to.eql(['7.17', '7.x']);
     });
 
     it('should resolve all-open and add all branches', () => {
       const branches = resolveTargets(mockVersions, ['backport:all-open']);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '7.x', '8.3', '8.4']);
     });
 
     it('should resolve hard-coded version labels', () => {
@@ -59,7 +59,7 @@ describe('backportTargets', () => {
 
     it('should resolve fill in gaps from hard-coded version labels', () => {
       const branches = resolveTargets(mockVersions, ['v7.16.0']);
-      expect(branches).to.eql(['7.16', '7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.16', '7.17', '7.x', '8.3', '8.4']);
     });
 
     it('should not fill in gaps from hard-coded version labels when using backport:version', () => {
@@ -74,7 +74,7 @@ describe('backportTargets', () => {
 
     it('should resolve hard-coded version labels and target labels', () => {
       const branches = resolveTargets(mockVersions, ['backport:prev-major', 'v8.5.0', 'v8.4.1', 'v7.17.1']);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '7.x', '8.3', '8.4']);
     });
 
     it('should resolve multiple labels for same branch and not duplicate', () => {
@@ -85,7 +85,7 @@ describe('backportTargets', () => {
         'v8.4.1',
         'v7.17.1',
       ]);
-      expect(branches).to.eql(['7.17', '8.3', '8.4']);
+      expect(branches).to.eql(['7.17', '7.x', '8.3', '8.4']);
     });
   });
 });

--- a/on-merge/backportTargets.test.ts
+++ b/on-merge/backportTargets.test.ts
@@ -22,7 +22,7 @@ describe('backportTargets', () => {
       mockVersions.previousMinor,
       mockVersions.previousMajor,
       { branch: '8.3', version: '8.3.15', currentMajor: true },
-      { branch: '7.x', version: '7.17.2', previousMajor: true }
+      { branch: '7.x', version: '7.17.2', previousMajor: true },
     ];
   });
 

--- a/on-merge/backportTargets.ts
+++ b/on-merge/backportTargets.ts
@@ -20,9 +20,7 @@ export function resolveTargets(versions: VersionsParsed, labelsOriginal: string[
   }
 
   if (labels.includes('backport:prev-major')) {
-    versions.all
-      .filter((version) => version.previousMajor)
-      .forEach((version) => targets.add(version.branch));
+    versions.all.filter((version) => version.previousMajor).forEach((version) => targets.add(version.branch));
   }
 
   if (labels.includes('backport:current-major')) {

--- a/on-merge/backportTargets.ts
+++ b/on-merge/backportTargets.ts
@@ -20,23 +20,21 @@ export function resolveTargets(versions: VersionsParsed, labelsOriginal: string[
   }
 
   if (labels.includes('backport:prev-major')) {
-    targets.add(versions.previousMajor.branch);
-    versions.others
+    versions.all
       .filter((version) => version.previousMajor)
       .forEach((version) => targets.add(version.branch));
   }
 
   if (labels.includes('backport:current-major')) {
-    targets.add(versions.previousMinor.branch);
-    versions.others
-      .filter((version) => version.currentMajor)
+    versions.all
+      .filter((version) => version.currentMajor && version.branch !== 'main')
       .forEach((version) => targets.add(version.branch));
   }
 
   if (labels.includes('backport:all-open')) {
-    targets.add(versions.previousMinor.branch);
-    targets.add(versions.previousMajor.branch);
-    versions.others.forEach((version) => targets.add(version.branch));
+    versions.all
+      .filter((version) => version.branch !== 'main')
+      .forEach((version) => targets.add(version.branch));
   }
 
   labels

--- a/on-merge/versions.js
+++ b/on-merge/versions.js
@@ -14,12 +14,10 @@ function parseVersions(versions) {
     if (!previousMajor) {
         throw new Error('versions.json is missing previous major version information');
     }
-    const others = versions.versions.filter((version) => !version.currentMinor && !version.previousMinor && !version.previousMajor);
     const parsed = {
         currentMinor,
         previousMinor,
         previousMajor,
-        others,
         all: versions.versions,
     };
     return parsed;

--- a/on-merge/versions.ts
+++ b/on-merge/versions.ts
@@ -20,7 +20,6 @@ export interface VersionsParsed {
   currentMinor: Version;
   previousMinor: Version;
   previousMajor: Version;
-  others: Version[];
   all: Version[];
 }
 
@@ -41,15 +40,10 @@ export function parseVersions(versions: Versions): VersionsParsed {
     throw new Error('versions.json is missing previous major version information');
   }
 
-  const others = versions.versions.filter(
-    (version) => !version.currentMinor && !version.previousMinor && !version.previousMajor,
-  );
-
   const parsed: VersionsParsed = {
     currentMinor,
     previousMinor,
     previousMajor,
-    others,
     all: versions.versions,
   };
 


### PR DESCRIPTION
version.others only included branches that were tagged with no identifier.  8.15 has the previousMajor tag and wasn't included, when we want it to be.

This drops the notion of other versions, and bases branch selection only off the label.