### PR TITLE
[backport] Respect branchLabelMapping in .backportrc.json

### DIFF
--- a/on-merge/backportTargets.test.ts
+++ b/on-merge/backportTargets.test.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import { resolveTargets } from './backportTargets';
-import { VersionsParsed } from './versions';
+import { VersionsParsed, VersionMap } from './versions';
 
 let mockVersions: VersionsParsed;
+let mockVersionMap: VersionMap;
 
 describe('backportTargets', () => {
   beforeEach(() => {
@@ -24,61 +25,91 @@ describe('backportTargets', () => {
       { branch: '8.3', version: '8.3.15', currentMajor: true },
       { branch: '7.x', version: '7.17.2', previousMajor: true },
     ];
+
+    mockVersionMap = {
+      '^v8.5.0$': 'main',
+      '^v7.17.2$': '7.x',
+      '^v(\\d+).(\\d+).\\d+$': '$1.$2',
+    };
   });
 
   describe('resolveTargets', () => {
     it('should resolve when no backport labels are present', () => {
-      const branches = resolveTargets(mockVersions, ['none']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['none']);
       expect(branches).to.eql([]);
     });
 
     it('should resolve prev-minor', () => {
-      const branches = resolveTargets(mockVersions, ['backport:prev-minor']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:prev-minor']);
       expect(branches).to.eql(['8.4']);
     });
 
     it('should resolve current-major', () => {
-      const branches = resolveTargets(mockVersions, ['backport:current-major']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:current-major']);
       expect(branches).to.eql(['8.3', '8.4']);
     });
 
     it('should resolve prev-major', () => {
-      const branches = resolveTargets(mockVersions, ['backport:prev-major']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:prev-major']);
       expect(branches).to.eql(['7.17', '7.x']);
     });
 
+    it('should map versions to branches using backport:version', () => {
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:version', 'v7.17.2']);
+      expect(branches).to.eql(['7.x']);
+    });
+
+    it('should map versions to branches using backport:prev-minor and fill in gaps 1', () => {
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:prev-minor', 'v8.3.0']);
+      expect(branches).to.eql(['8.3', '8.4']);
+    });
+
+    it('should map versions to branches using backport:prev-minor and fill in gaps2', () => {
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:prev-minor', 'v7.17.0']);
+      expect(branches).to.eql(['7.17', '7.x', '8.3', '8.4']);
+    });
+
     it('should resolve all-open and add all branches', () => {
-      const branches = resolveTargets(mockVersions, ['backport:all-open']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['backport:all-open']);
       expect(branches).to.eql(['7.17', '7.x', '8.3', '8.4']);
     });
 
     it('should resolve hard-coded version labels', () => {
-      const branches = resolveTargets(mockVersions, ['v8.5.0', 'v8.4.1']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['v8.5.0', 'v8.4.1']);
       expect(branches).to.eql(['8.4']);
     });
 
     it('should resolve fill in gaps from hard-coded version labels', () => {
-      const branches = resolveTargets(mockVersions, ['v7.16.0']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['v7.16.0']);
       expect(branches).to.eql(['7.16', '7.17', '7.x', '8.3', '8.4']);
     });
 
     it('should not fill in gaps from hard-coded version labels when using backport:version', () => {
-      const branches = resolveTargets(mockVersions, ['backport:version', 'v7.15.0', 'v8.4.5']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, [
+        'backport:version',
+        'v7.15.0',
+        'v8.4.5',
+      ]);
       expect(branches).to.eql(['7.15', '8.4']);
     });
 
     it('should not fill in gaps from hard-coded version labels when using auto-backport', () => {
-      const branches = resolveTargets(mockVersions, ['auto-backport', 'v7.15.0', 'v8.4.5']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, ['auto-backport', 'v7.15.0', 'v8.4.5']);
       expect(branches).to.eql(['7.15', '8.4']);
     });
 
     it('should resolve hard-coded version labels and target labels', () => {
-      const branches = resolveTargets(mockVersions, ['backport:prev-major', 'v8.5.0', 'v8.4.1', 'v7.17.1']);
+      const branches = resolveTargets(mockVersions, mockVersionMap, [
+        'backport:prev-major',
+        'v8.5.0',
+        'v8.4.1',
+        'v7.17.1',
+      ]);
       expect(branches).to.eql(['7.17', '7.x', '8.3', '8.4']);
     });
 
     it('should resolve multiple labels for same branch and not duplicate', () => {
-      const branches = resolveTargets(mockVersions, [
+      const branches = resolveTargets(mockVersions, mockVersionMap, [
         'backport:prev-major',
         'backport:prev-minor',
         'v8.5.0',

--- a/on-merge/versions.ts
+++ b/on-merge/versions.ts
@@ -23,6 +23,10 @@ export interface VersionsParsed {
   all: Version[];
 }
 
+export interface VersionMap {
+  [regex: string]: string;
+}
+
 export function parseVersions(versions: Versions): VersionsParsed {
   const currentMinor = versions.versions.find((version) => version.currentMinor);
   const previousMinor = versions.versions.find((version) => version.previousMinor);


### PR DESCRIPTION
Currently `backport:version,v8.16.0` will attempt to backport to the non-existent 8.16 branch.  We want this to instead respect the branchLabelMapping in [.backportrc.json](https://github.com/elastic/kibana/blob/b31d119e5532c362c44a134547f461fd7db56770/.backportrc.json#L55-L59) and target the 8.x branch.

The backport tool already understands how to map branch labels, but we have a translation layer in front in support of several other labels, and supply it with the target branches directly.  Given what's already implemented I believe this approach is simpler than splitting the runtime into two calls.