### PR TITLE
Correct `backport:version` without version labels to `backport:skip`

### DIFF
--- a/on-merge/on-merge.integration.test.ts
+++ b/on-merge/on-merge.integration.test.ts
@@ -219,7 +219,7 @@ describe('On-Merge Action', () => {
     });
 
     // TODO: review this behavior - what should we do when backport:version is set but no targets set?
-    it('should skip backport when no targets are found', async () => {
+    it('should correct to backport:skip when no targets are found', async () => {
       // Setup: PR with only current version label (no backport targets)
       mockContext.payload.pull_request.labels = [{ name: 'backport:version' }];
 
@@ -230,6 +230,12 @@ describe('On-Merge Action', () => {
       // Verify: backportRun should not be called
       expect(mockBackportRun).not.toHaveBeenCalled();
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+      expect(mockOctokit.rest.issues.removeLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'backport:version' }),
+      );
+      expect(mockOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['backport:skip'] }),
+      );
     });
 
     it('should run successful backport flow with valid targets', async () => {


### PR DESCRIPTION
We've noticed some developers are adding `backport:version` without a version label. This would cause the current version label to be added on merge. This will upset the reminder logic, because it sees a `backport:version` but no backports. 

This PR corrects these cases to `backport:skip`.