### PR TITLE
[Discover] Fix "mapping" default to allow action inputs to override it

### DIFF
--- a/github-projects/map-labels/index.js
+++ b/github-projects/map-labels/index.js
@@ -60,8 +60,8 @@ const parsedCliArgs = (0, yargs_1.default)(process.argv.slice(2))
     .option('mapping', {
     alias: 'm',
     type: 'string',
-    describe: 'The mapping file to use',
-    default: 'mapping-sizes-and-impact.json',
+    describe: 'The mapping file to use (default: mapping-sizes-and-impact.json)',
+    // the default is defined in combineAndVerifyArgs to allow action inputs to override it
 })
     .option('repo', {
     alias: 'r',
@@ -135,6 +135,7 @@ function combineAndVerifyArgs(argsFromActionInputs, argsFromCli) {
     const defaults = {
         owner: tryGetOwnerFromContext(),
         issueNumber: [],
+        mapping: 'mapping-sizes-and-impact.json',
     };
     const combinedArgs = (0, utils_1.merge)((0, utils_1.merge)(defaults, argsFromActionInputs), argsFromCli);
     verifyExpectedArgs(combinedArgs);

--- a/github-projects/map-labels/index.ts
+++ b/github-projects/map-labels/index.ts
@@ -48,8 +48,8 @@ const parsedCliArgs: ActionArgs = yargs(process.argv.slice(2))
   .option('mapping', {
     alias: 'm',
     type: 'string',
-    describe: 'The mapping file to use',
-    default: 'mapping-sizes-and-impact.json',
+    describe: 'The mapping file to use (default: mapping-sizes-and-impact.json)',
+    // the default is defined in combineAndVerifyArgs to allow action inputs to override it
   })
   .option('repo', {
     alias: 'r',
@@ -135,6 +135,7 @@ function combineAndVerifyArgs(argsFromActionInputs: ActionArgs, argsFromCli: Act
   const defaults = {
     owner: tryGetOwnerFromContext(),
     issueNumber: [] as number[],
+    mapping: 'mapping-sizes-and-impact.json',
   };
 
   const combinedArgs: ActionArgs = merge(merge(defaults, argsFromActionInputs), argsFromCli);


### PR DESCRIPTION
- Follow up for https://github.com/elastic/kibana-github-actions/pull/65

This PR fixes handling of "mapping" so it can be overridden. For example, for the 787 project case the custom argument was ignored: https://github.com/elastic/kibana/actions/runs/20747645573/job/59568733554

<img width="634" height="213" alt="Screenshot 2026-01-06 at 14 16 12" src="https://github.com/user-attachments/assets/6576a703-1aaf-4674-86b7-6b48a39dcea1" />
