### PR TITLE
Add logging to backport/on-merge

### DIFF
--- a/on-merge/backportTargets.js
+++ b/on-merge/backportTargets.js
@@ -1,7 +1,31 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.resolveTargets = exports.BACKPORT_LABELS = void 0;
 const util_1 = require("./util");
+const core = __importStar(require("@actions/core"));
 exports.BACKPORT_LABELS = {
     SKIP: 'backport:skip',
     ALL_OPEN: 'backport:all-open',
@@ -10,40 +34,59 @@ exports.BACKPORT_LABELS = {
 function resolveTargets(versions, versionToBranchMap, labelsOriginal) {
     const targets = new Set();
     const labels = labelsOriginal.map((label) => label.toLowerCase());
+    core.info(`[RESOLVE-TARGETS] Input labels (lowercased): ${labels.join(', ')}`);
     if (labels.includes(exports.BACKPORT_LABELS.SKIP)) {
         // backport:skip
+        core.info(`[RESOLVE-TARGETS] Found ${exports.BACKPORT_LABELS.SKIP} label, returning empty targets`);
         return [];
     }
     if (labels.includes(exports.BACKPORT_LABELS.ALL_OPEN)) {
         // backport:all-open
-        versions.all
-            .filter((version) => version.branchType !== 'unmaintained' && version.branchType !== 'development')
-            .forEach((version) => targets.add(version.branch));
+        core.info(`[RESOLVE-TARGETS] Found ${exports.BACKPORT_LABELS.ALL_OPEN} label, selecting all maintained versions`);
+        const selectedVersions = versions.all.filter((version) => version.branchType !== 'unmaintained' && version.branchType !== 'development');
+        core.info(`[RESOLVE-TARGETS] Selected ${selectedVersions.length} versions (excluding unmaintained/development)`);
+        selectedVersions.forEach((version) => {
+            core.info(`[RESOLVE-TARGETS]   Adding target: ${version.branch} (v${version.version}, type: ${version.branchType || 'N/A'})`);
+            targets.add(version.branch);
+        });
     }
     else if (labels.includes(exports.BACKPORT_LABELS.VERSION)) {
         // backport:version
+        core.info(`[RESOLVE-TARGETS] Found ${exports.BACKPORT_LABELS.VERSION} label, resolving version labels to branches`);
         const versionLabels = (0, util_1.getVersionLabels)(labels);
+        core.info(`[RESOLVE-TARGETS] Found ${versionLabels.length} version label(s): ${versionLabels.join(', ')}`);
         versionLabels.forEach((label) => {
             let branch = null;
             for (const [regex, replacement] of Object.entries(versionToBranchMap)) {
                 const matcher = new RegExp(regex);
                 if (matcher.test(label)) {
                     branch = label.replace(matcher, replacement);
+                    core.info(`[RESOLVE-TARGETS]   Label ${label} matched regex ${regex}, mapped to branch: ${branch}`);
                     break;
                 }
             }
             if (branch && branch !== 'main') {
+                core.info(`[RESOLVE-TARGETS]   Adding target branch: ${branch}`);
                 targets.add(branch);
+            }
+            else if (branch === 'main') {
+                core.info(`[RESOLVE-TARGETS]   Skipping 'main' branch for label ${label}`);
+            }
+            else {
+                core.info(`[RESOLVE-TARGETS]   No branch mapping found for label ${label}`);
             }
         });
     }
     else {
         // Missing backport labels, but let's not error just now, we haven't been doing that
+        core.info(`[RESOLVE-TARGETS] No backport control labels found (expected one of: ${Object.values(exports.BACKPORT_LABELS).join(', ')})`);
         // throw new Error(
         //   'No backport labels found, should be one of: ' + Object.values(BACKPORT_LABELS).join(', '),
         // );
     }
-    return [...targets].sort();
+    const sortedTargets = [...targets].sort();
+    core.info(`[RESOLVE-TARGETS] Final targets (${sortedTargets.length}): ${sortedTargets.join(', ')}`);
+    return sortedTargets;
 }
 exports.resolveTargets = resolveTargets;
 //# sourceMappingURL=backportTargets.js.map

--- a/on-merge/backportTargets.ts
+++ b/on-merge/backportTargets.ts
@@ -1,5 +1,6 @@
 import { VersionsParsed, VersionMap } from './versions';
 import { getVersionLabels } from './util';
+import * as core from '@actions/core';
 
 export const BACKPORT_LABELS = {
   SKIP: 'backport:skip',
@@ -15,40 +16,73 @@ export function resolveTargets(
   const targets = new Set<string>();
 
   const labels = labelsOriginal.map((label) => label.toLowerCase());
+  core.info(`[RESOLVE-TARGETS] Input labels (lowercased): ${labels.join(', ')}`);
 
   if (labels.includes(BACKPORT_LABELS.SKIP)) {
     // backport:skip
+    core.info(`[RESOLVE-TARGETS] Found ${BACKPORT_LABELS.SKIP} label, returning empty targets`);
     return [];
   }
 
   if (labels.includes(BACKPORT_LABELS.ALL_OPEN)) {
     // backport:all-open
-    versions.all
-      .filter((version) => version.branchType !== 'unmaintained' && version.branchType !== 'development')
-      .forEach((version) => targets.add(version.branch));
+    core.info(`[RESOLVE-TARGETS] Found ${BACKPORT_LABELS.ALL_OPEN} label, selecting all maintained versions`);
+    const selectedVersions = versions.all.filter(
+      (version) => version.branchType !== 'unmaintained' && version.branchType !== 'development',
+    );
+    core.info(
+      `[RESOLVE-TARGETS] Selected ${selectedVersions.length} versions (excluding unmaintained/development)`,
+    );
+    selectedVersions.forEach((version) => {
+      core.info(
+        `[RESOLVE-TARGETS]   Adding target: ${version.branch} (v${version.version}, type: ${
+          version.branchType || 'N/A'
+        })`,
+      );
+      targets.add(version.branch);
+    });
   } else if (labels.includes(BACKPORT_LABELS.VERSION)) {
     // backport:version
+    core.info(
+      `[RESOLVE-TARGETS] Found ${BACKPORT_LABELS.VERSION} label, resolving version labels to branches`,
+    );
     const versionLabels = getVersionLabels(labels);
+    core.info(
+      `[RESOLVE-TARGETS] Found ${versionLabels.length} version label(s): ${versionLabels.join(', ')}`,
+    );
     versionLabels.forEach((label) => {
       let branch = null;
       for (const [regex, replacement] of Object.entries(versionToBranchMap)) {
         const matcher = new RegExp(regex);
         if (matcher.test(label)) {
           branch = label.replace(matcher, replacement);
+          core.info(`[RESOLVE-TARGETS]   Label ${label} matched regex ${regex}, mapped to branch: ${branch}`);
           break;
         }
       }
 
       if (branch && branch !== 'main') {
+        core.info(`[RESOLVE-TARGETS]   Adding target branch: ${branch}`);
         targets.add(branch);
+      } else if (branch === 'main') {
+        core.info(`[RESOLVE-TARGETS]   Skipping 'main' branch for label ${label}`);
+      } else {
+        core.info(`[RESOLVE-TARGETS]   No branch mapping found for label ${label}`);
       }
     });
   } else {
     // Missing backport labels, but let's not error just now, we haven't been doing that
+    core.info(
+      `[RESOLVE-TARGETS] No backport control labels found (expected one of: ${Object.values(
+        BACKPORT_LABELS,
+      ).join(', ')})`,
+    );
     // throw new Error(
     //   'No backport labels found, should be one of: ' + Object.values(BACKPORT_LABELS).join(', '),
     // );
   }
 
-  return [...targets].sort();
+  const sortedTargets = [...targets].sort();
+  core.info(`[RESOLVE-TARGETS] Final targets (${sortedTargets.length}): ${sortedTargets.join(', ')}`);
+  return sortedTargets;
 }

--- a/on-merge/github.js
+++ b/on-merge/github.js
@@ -1,7 +1,31 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.GithubWrapper = void 0;
 const github_1 = require("@actions/github");
+const core = __importStar(require("@actions/core"));
 class GithubWrapper {
     constructor({ accessToken, owner, repo }) {
         this.github = (0, github_1.getOctokit)(accessToken).rest;
@@ -9,6 +33,7 @@ class GithubWrapper {
         this.repo = repo;
     }
     async getFileContent(filePath, ref = 'main') {
+        core.info(`[GH-API] Fetching file content: ${filePath} (ref: ${ref})`);
         const response = await this.github.repos.getContent({
             owner: this.owner,
             repo: this.repo,
@@ -16,12 +41,14 @@ class GithubWrapper {
             path: filePath,
         });
         const content = Buffer.from(response.data.content, 'base64').toString();
+        core.info(`[GH-API] Successfully fetched ${filePath}, size: ${content.length} bytes`);
         if (filePath.endsWith('.json')) {
             return JSON.parse(content);
         }
         return content;
     }
     async addLabels(issue, labels) {
+        core.info(`[GH-API] Adding labels to issue #${issue.number}: ${labels.join(', ')}`);
         const response = await this.github.issues.addLabels({
             owner: this.owner,
             repo: this.repo,
@@ -33,36 +60,45 @@ class GithubWrapper {
                 issue.labels.push({ name: label });
             }
         }
+        core.info(`[GH-API] Labels added successfully to issue #${issue.number}`);
         return response.data;
     }
     removeLabels(issue, labels) {
+        core.info(`[GH-API] Removing labels from issue #${issue.number}: ${labels.join(', ')}`);
         return Promise.all(labels.map((label) => this.removeLabel(issue, label)));
     }
     async removeLabel(issue, label) {
+        core.info(`[GH-API] Removing label from issue #${issue.number}: ${label}`);
         issue.labels = issue.labels.filter((l) => l.name !== label);
-        return this.github.issues.removeLabel({
+        const response = await this.github.issues.removeLabel({
             owner: this.owner,
             repo: this.repo,
             issue_number: issue.number,
             name: label,
         });
+        core.info(`[GH-API] Label removed successfully from issue #${issue.number}: ${label}`);
+        return response;
     }
     async createComment(issueNumber, body) {
+        core.info(`[GH-API] Creating comment on issue #${issueNumber}, length: ${body.length} chars`);
         const response = await this.github.issues.createComment({
             owner: this.owner,
             repo: this.repo,
             issue_number: issueNumber,
             body,
         });
+        core.info(`[GH-API] Comment created successfully on issue #${issueNumber}`);
         return response.data;
     }
     async updatePullRequest(number, updateFields) {
+        core.info(`[GH-API] Updating PR #${number}, body length: ${updateFields.body.length} chars`);
         const response = await this.github.pulls.update({
             owner: this.owner,
             repo: this.repo,
             pull_number: number,
             ...updateFields,
         });
+        core.info(`[GH-API] PR #${number} updated successfully`);
         return response.data;
     }
 }

--- a/on-merge/github.ts
+++ b/on-merge/github.ts
@@ -1,4 +1,5 @@
 import { getOctokit } from '@actions/github';
+import * as core from '@actions/core';
 
 type GithubOptions = {
   accessToken: string;
@@ -25,6 +26,7 @@ export class GithubWrapper {
   }
 
   async getFileContent(filePath: string, ref = 'main') {
+    core.info(`[GH-API] Fetching file content: ${filePath} (ref: ${ref})`);
     const response = await this.github.repos.getContent({
       owner: this.owner,
       repo: this.repo,
@@ -32,6 +34,7 @@ export class GithubWrapper {
       path: filePath,
     });
     const content = Buffer.from((response.data as any).content, 'base64').toString();
+    core.info(`[GH-API] Successfully fetched ${filePath}, size: ${content.length} bytes`);
     if (filePath.endsWith('.json')) {
       return JSON.parse(content);
     }
@@ -39,6 +42,7 @@ export class GithubWrapper {
   }
 
   async addLabels(issue: HasNumber & HasLabels, labels: string[]) {
+    core.info(`[GH-API] Adding labels to issue #${issue.number}: ${labels.join(', ')}`);
     const response = await this.github.issues.addLabels({
       owner: this.owner,
       repo: this.repo,
@@ -50,40 +54,49 @@ export class GithubWrapper {
         issue.labels.push({ name: label } as any);
       }
     }
+    core.info(`[GH-API] Labels added successfully to issue #${issue.number}`);
     return response.data;
   }
 
   removeLabels(issue: HasNumber & HasLabels, labels: string[]) {
+    core.info(`[GH-API] Removing labels from issue #${issue.number}: ${labels.join(', ')}`);
     return Promise.all(labels.map((label) => this.removeLabel(issue, label)));
   }
 
   async removeLabel(issue: HasNumber & HasLabels, label: string) {
+    core.info(`[GH-API] Removing label from issue #${issue.number}: ${label}`);
     issue.labels = issue.labels.filter((l) => l.name !== label);
-    return this.github.issues.removeLabel({
+    const response = await this.github.issues.removeLabel({
       owner: this.owner,
       repo: this.repo,
       issue_number: issue.number,
       name: label,
     });
+    core.info(`[GH-API] Label removed successfully from issue #${issue.number}: ${label}`);
+    return response;
   }
 
   async createComment(issueNumber: number, body: string) {
+    core.info(`[GH-API] Creating comment on issue #${issueNumber}, length: ${body.length} chars`);
     const response = await this.github.issues.createComment({
       owner: this.owner,
       repo: this.repo,
       issue_number: issueNumber,
       body,
     });
+    core.info(`[GH-API] Comment created successfully on issue #${issueNumber}`);
     return response.data;
   }
 
   async updatePullRequest(number: number, updateFields: { body: string }) {
+    core.info(`[GH-API] Updating PR #${number}, body length: ${updateFields.body.length} chars`);
     const response = await this.github.pulls.update({
       owner: this.owner,
       repo: this.repo,
       pull_number: number,
       ...updateFields,
     });
+    core.info(`[GH-API] PR #${number} updated successfully`);
     return response.data;
   }
 }

--- a/on-merge/index.js
+++ b/on-merge/index.js
@@ -132,7 +132,7 @@ async function runOnMergeAction() {
         core.info(`[BACKPORT-RUN] Backport config: assignees=[${pullRequest.user.login}], autoMerge=true, autoMergeMethod=squash`);
         const logFilePath = path.join(os.tmpdir(), `backport-${pullRequest.number}.log`);
         core.info(`[BACKPORT-RUN] Log file: ${logFilePath}`);
-        const stopTailing = (0, util_1.tailFileToActions)(logFilePath);
+        const stopTailing = (0, util_1.tailFileToActions)({ filePath: logFilePath, logger: core });
         try {
             const result = await (0, backport_1.backportRun)({
                 options: {

--- a/on-merge/index.ts
+++ b/on-merge/index.ts
@@ -150,7 +150,7 @@ async function runOnMergeAction() {
     );
     const logFilePath = path.join(os.tmpdir(), `backport-${pullRequest.number}.log`);
     core.info(`[BACKPORT-RUN] Log file: ${logFilePath}`);
-    const stopTailing = tailFileToActions(logFilePath);
+    const stopTailing = tailFileToActions({ filePath: logFilePath, logger: core });
     try {
       const result = await backportRun({
         options: {

--- a/on-merge/index.ts
+++ b/on-merge/index.ts
@@ -2,6 +2,9 @@ import * as core from '@actions/core';
 import { context } from '@actions/github';
 import { PullRequestEvent } from '@octokit/webhooks-definitions/schema';
 import { backportRun } from 'backport';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { BACKPORT_LABELS, resolveTargets } from './backportTargets';
 import { getGithubActionURL, getPrBackportData, getVersionLabels, labelsContain } from './util';
 import { parseVersions } from './versions';
@@ -34,30 +37,49 @@ async function runOnMergeAction() {
   const debounceTimeout =
     parseInt(process.env.BACKPORT_DEBOUNCE_TIMEOUT ?? '', 10) || DEFAULT_DEBOUNCE_TIMEOUT;
 
+  core.info(`[INIT] Starting on-merge action for repo: ${repo.owner}/${repo.repo}`);
+  core.info(`[INIT] Payload action: ${payload.action}, event: ${context.eventName}`);
+
   if (!payload.pull_request) {
     throw Error('Only pull_request events are supported.');
   }
 
   const accessToken = core.getInput('github_token', { required: true });
   const githubWrapper = new GithubWrapper({ accessToken, owner: repo.owner, repo: repo.repo });
+  core.info(`[INIT] GitHub wrapper initialized for ${repo.owner}/${repo.repo}`);
 
+  core.info('[CONFIG] Fetching .backportrc.json...');
   const backportConfig = await githubWrapper.getFileContent('.backportrc.json');
   const versionMap = backportConfig?.branchLabelMapping || {};
+  core.info(`[CONFIG] Loaded branchLabelMapping with ${Object.keys(versionMap).length} mappings`);
 
+  core.info('[CONFIG] Fetching versions.json...');
   const versionsConfig = await githubWrapper.getFileContent('versions.json');
   const versions = parseVersions(versionsConfig);
   const currentLabel = `v${versions.current.version}`;
+  core.info(
+    `[CONFIG] Current version: ${versions.current.version}, branch: ${versions.current.branch}, total versions: ${versions.all.length}`,
+  );
 
   const pullRequestPayload = payload as PullRequestEvent;
   const pullRequest = pullRequestPayload.pull_request;
+  core.info(`[PR] Processing PR #${pullRequest.number}: ${pullRequest.title}`);
+  core.info(`[PR] Base branch: ${pullRequest.base.ref}, Head branch: ${pullRequest.head.ref}`);
+  core.info(
+    `[PR] PR state: ${pullRequest.state}, merged: ${pullRequest.merged}, labels: ${pullRequest.labels
+      .map((l) => l.name)
+      .join(', ')}`,
+  );
 
   if (pullRequest.base.ref === 'main') {
+    core.info('[WORKFLOW] PR base is main branch, processing backport logic...');
     // Fix the backport:version label, only when the PR is closed:
     // - if the only version label is the current version, or no version labels => replace backport:version with backport:skip
     if (
       payload.action !== 'labeled' &&
       (isPRBackportToCurrentRelease(pullRequest, currentLabel) || hasBackportVersionWithNoTarget(pullRequest))
     ) {
+      core.info(`[LABELS] Auto-adjusting labels: detected backport to current release or no target`);
       await githubWrapper.removeLabels(pullRequest, [BACKPORT_LABELS.VERSION]);
       await githubWrapper.addLabels(pullRequest, [BACKPORT_LABELS.SKIP]);
       core.info("Adjusted labels: removing 'backport:version' and adding 'backport:skip'");
@@ -65,40 +87,62 @@ async function runOnMergeAction() {
 
     // Add current target label
     if (!labelsContain(pullRequest.labels, currentLabel)) {
+      core.info(`[LABELS] Adding current version label: ${currentLabel}`);
       await githubWrapper.addLabels(pullRequest, [currentLabel]);
+    } else {
+      core.info(`[LABELS] Current version label already present: ${currentLabel}`);
     }
 
     // Skip backport if skip label is present
     if (labelsContain(pullRequest.labels, BACKPORT_LABELS.SKIP)) {
-      core.info("Backport skipped because 'backport:skip' label is present");
+      core.info("[EXIT] Backport skipped because 'backport:skip' label is present");
       return;
     }
 
     // Find backport targets
     const labelNames = pullRequest.labels.map((label) => label.name);
+    core.info(`[TARGETS] Resolving backport targets from labels: ${labelNames.join(', ')}`);
     const targets = resolveTargets(versions, versionMap, labelNames);
 
     if (!targets.length) {
-      core.info(`Backport skipped, because no backport targets found.`);
+      core.info(
+        `[EXIT] Backport skipped, because no backport targets found. Labels checked: ${labelNames.join(
+          ', ',
+        )}`,
+      );
       return;
     }
 
+    core.info(`[TARGETS] Resolved ${targets.length} backport target(s): ${targets.join(', ')}`);
+
     // Sleep for debounceTimeout to debounce multiple concurrent runs
-    core.info(`Waiting ${(debounceTimeout / 1000).toFixed(1)}s to debounce multiple concurrent runs...`);
+    core.info(
+      `[DEBOUNCE] Waiting ${(debounceTimeout / 1000).toFixed(1)}s to debounce multiple concurrent runs...`,
+    );
     await new Promise((resolve) => setTimeout(resolve, debounceTimeout));
     if (workflowState.wasInterrupted) {
-      core.warning('Workflow was interrupted. Exiting before starting backport...');
+      core.warning('[EXIT] Workflow was interrupted. Exiting before starting backport...');
       return;
     } else {
       core.info(
-        `Backporting to target branches: ${targets.join(', ')} based on labels: ${labelNames.join(', ')}`,
+        `[BACKPORT] Starting backport to target branches: ${targets.join(
+          ', ',
+        )} based on labels: ${labelNames.join(', ')}`,
       );
     }
 
     // Add comment about planned backports and update PR body with backport metadata
+    core.info('[PR-UPDATE] Updating PR with backport info...');
     await updatePRWithBackportInfo(githubWrapper, pullRequest, targets);
+    core.info('[PR-UPDATE] PR updated successfully');
 
     // Start backport for the calculated targets
+    core.info(
+      `[BACKPORT-RUN] Initiating backport for PR #${pullRequest.number} to ${targets.length} target(s)`,
+    );
+    core.info(
+      `[BACKPORT-RUN] Backport config: assignees=[${pullRequest.user.login}], autoMerge=true, autoMergeMethod=squash`,
+    );
     try {
       const result = await backportRun({
         options: {
@@ -115,7 +159,9 @@ async function runOnMergeAction() {
           publishStatusCommentOnSuccess: true, // TODO this will flip to false once we have backport summaries implemented
         },
       });
+      core.info(`[BACKPORT-RUN] Backport completed with status: ${result.status}`);
       if (result.status === 'failure') {
+        core.error(`[BACKPORT-RUN] Backport failed with error type: ${typeof result.error}`);
         if (typeof result.error === 'string') {
           throw new Error(result.error);
         } else if (result.error instanceof Error) {
@@ -124,8 +170,11 @@ async function runOnMergeAction() {
           throw new Error('Backport failed for an unknown reason');
         }
       }
+      core.info('[SUCCESS] Backport process completed successfully');
     } catch (err) {
-      core.error('Backport failed');
+      core.error(`[BACKPORT-ERROR] Backport failed for PR #${pullRequest.number}: ${err.message}`);
+      core.error('[BACKPORT-ERROR] Full error:');
+      core.error(err);
       core.setFailed(err.message);
       githubWrapper
         .createComment(
@@ -133,27 +182,41 @@ async function runOnMergeAction() {
           `Backport failed. Please check the action logs for details. \n\n${getGithubActionURL(process.env)}`,
         )
         .catch(() => {
-          core.error('Failed to create comment on PR about backport failure');
+          core.error('[BACKPORT-ERROR] Failed to create comment on PR about backport failure');
         });
     }
   } else if (labelsContain(pullRequest.labels, 'backport')) {
+    core.info(
+      `[WORKFLOW] PR base is not main (${pullRequest.base.ref}), checking if this is a backport PR...`,
+    );
     // Mark original PR with backport target labels
     const prData = getPrBackportData(pullRequest.body);
     if (prData) {
+      core.info(`[BACKPORT-LABEL] Found ${prData.length} source PR(s) to label`);
       const prPackageVersion = (await githubWrapper.getFileContent('package.json', pullRequest.base.ref))
         .version;
+      core.info(`[BACKPORT-LABEL] Package version for branch ${pullRequest.base.ref}: ${prPackageVersion}`);
 
       for (const pr of prData) {
         if (!pr.sourcePullRequest) {
+          core.info(`[BACKPORT-LABEL] Skipping PR data entry without sourcePullRequest`);
           continue;
         }
 
+        core.info(`[BACKPORT-LABEL] Adding label v${prPackageVersion} to source PR #${pr.sourcePullRequest}`);
         await githubWrapper.addLabels(
           pr.sourcePullRequest as any,
           [`v${prPackageVersion}`], // TODO switch this to use getVersionLabel when it's appropriate to increment patch versions after BCs
         );
       }
+      core.info('[SUCCESS] Backport labeling completed');
+    } else {
+      core.info('[WORKFLOW] No backport PR data found in PR body');
     }
+  } else {
+    core.info(
+      `[EXIT] PR base is not main (${pullRequest.base.ref}) and no backport label present. Nothing to do.`,
+    );
   }
 }
 
@@ -178,6 +241,9 @@ async function updatePRWithBackportInfo(
   targets: string[],
 ) {
   try {
+    core.info(
+      `[PR-COMMENT] Creating comment for PR #${pullRequest.number} about backport to: ${targets.join(', ')}`,
+    );
     const actionUrl = getGithubActionURL(process.env);
     await githubWrapper.createComment(
       pullRequest.number,
@@ -185,14 +251,18 @@ async function updatePRWithBackportInfo(
         .filter(Boolean)
         .join('\n\n'),
     );
+    core.info('[PR-COMMENT] Comment created successfully');
 
     // Mark PR body with backport targets
+    core.info('[PR-BODY] Updating PR body with backport metadata...');
     await githubWrapper.updatePullRequest(pullRequest.number, {
       body: `${pullRequest.body}\n\n<!--ONMERGE ${JSON.stringify({
         backportTargets: targets,
       })} ONMERGE-->`,
     });
+    core.info('[PR-BODY] PR body updated successfully');
   } catch (error) {
+    core.error(`[PR-UPDATE-ERROR] Failed to update PR #${pullRequest.number}: ${error.message}`);
     core.error(error);
     core.setFailed(error.message);
   }

--- a/on-merge/on-merge.integration.test.ts
+++ b/on-merge/on-merge.integration.test.ts
@@ -34,6 +34,7 @@ const mockContext = {
       base: { ref: 'main' },
       user: { login: 'test-user' },
       body: 'Default PR body',
+      head: { ref: 'test-branch' },
     },
   },
 };
@@ -73,6 +74,7 @@ const defaultContext = {
       base: { ref: 'main' },
       user: { login: 'test-user' },
       body: 'Default PR body',
+      head: { ref: 'test-branch' },
     },
   },
   eventName: 'pull_request',
@@ -283,6 +285,7 @@ describe('On-Merge Action', () => {
           repoName: 'kibana',
           accessToken: 'test-token',
           interactive: false,
+          logFilePath: expect.any(String),
           pullNumber: 12345,
           assignees: ['test-user'],
           autoMerge: true,

--- a/on-merge/util.js
+++ b/on-merge/util.js
@@ -1,11 +1,36 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getGithubActionURL = exports.getVersionLabels = exports.labelsContain = exports.getVersionLabel = exports.getArtifactsApiVersions = exports.getPrBackportData = void 0;
+exports.tailFileToActions = exports.getGithubActionURL = exports.getVersionLabels = exports.labelsContain = exports.getVersionLabel = exports.getArtifactsApiVersions = exports.getPrBackportData = void 0;
 const axios_1 = __importDefault(require("axios"));
 const semver_1 = __importDefault(require("semver"));
+const core = __importStar(require("@actions/core"));
+const fs = __importStar(require("fs"));
 function getPrBackportData(prBody) {
     const prDataMatch = prBody === null || prBody === void 0 ? void 0 : prBody.match(/<!--BACKPORT (.*?) BACKPORT-->/s);
     if (prDataMatch === null || prDataMatch === void 0 ? void 0 : prDataMatch[1]) {
@@ -52,4 +77,74 @@ function getGithubActionURL(env) {
     return '';
 }
 exports.getGithubActionURL = getGithubActionURL;
+/**
+ * Tails a log file and forwards new lines to GitHub Actions output in real-time.
+ * Returns a stop function that flushes remaining content and cleans up.
+ */
+function tailFileToActions(filePath, intervalMs = 1000) {
+    let offset = 0;
+    let buffer = '';
+    let stopped = false;
+    function flush() {
+        var _a, _b, _c, _d;
+        let content;
+        try {
+            const fd = fs.openSync(filePath, 'r');
+            const stat = fs.fstatSync(fd);
+            if (stat.size <= offset) {
+                fs.closeSync(fd);
+                return;
+            }
+            const readBuf = Buffer.alloc(stat.size - offset);
+            fs.readSync(fd, readBuf, 0, readBuf.length, offset);
+            offset = stat.size;
+            fs.closeSync(fd);
+            content = readBuf.toString('utf-8');
+        }
+        catch {
+            return;
+        }
+        buffer += content;
+        const lines = buffer.split('\n');
+        buffer = (_a = lines.pop()) !== null && _a !== void 0 ? _a : '';
+        for (const line of lines) {
+            if (!line.trim())
+                continue;
+            try {
+                const entry = JSON.parse(line);
+                const level = (_b = entry.level) !== null && _b !== void 0 ? _b : 'info';
+                const ts = (_c = entry.timestamp) !== null && _c !== void 0 ? _c : '';
+                const msg = (_d = entry.message) !== null && _d !== void 0 ? _d : '';
+                const meta = entry.metadata && Object.keys(entry.metadata).length ? JSON.stringify(entry.metadata) : '';
+                const formatted = [`[BACKPORT-LIB]`, ts, `[${level}]`, msg, meta].filter(Boolean).join(' ');
+                if (level === 'error') {
+                    core.error(formatted);
+                }
+                else if (level === 'warn') {
+                    core.warning(formatted);
+                }
+                else {
+                    core.info(formatted);
+                }
+            }
+            catch {
+                core.info(`[BACKPORT-LIB] ${line}`);
+            }
+        }
+    }
+    const timer = setInterval(() => {
+        if (!stopped)
+            flush();
+    }, intervalMs);
+    return () => {
+        stopped = true;
+        clearInterval(timer);
+        flush();
+        if (buffer.trim()) {
+            core.info(`[BACKPORT-LIB] ${buffer}`);
+            buffer = '';
+        }
+    };
+}
+exports.tailFileToActions = tailFileToActions;
 //# sourceMappingURL=util.js.map

--- a/on-merge/util.ts
+++ b/on-merge/util.ts
@@ -1,6 +1,8 @@
 import { Commit } from 'backport';
 import axios from 'axios';
 import semver from 'semver';
+import * as core from '@actions/core';
+import * as fs from 'fs';
 
 export function getPrBackportData(prBody: string | undefined | null) {
   const prDataMatch = prBody?.match(/<!--BACKPORT (.*?) BACKPORT-->/s);
@@ -57,4 +59,73 @@ export function getGithubActionURL(env: typeof process.env) {
     return `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`;
   }
   return '';
+}
+
+/**
+ * Tails a log file and forwards new lines to GitHub Actions output in real-time.
+ * Returns a stop function that flushes remaining content and cleans up.
+ */
+export function tailFileToActions(filePath: string, intervalMs = 1000): () => void {
+  let offset = 0;
+  let buffer = '';
+  let stopped = false;
+
+  function flush() {
+    let content: string;
+    try {
+      const fd = fs.openSync(filePath, 'r');
+      const stat = fs.fstatSync(fd);
+      if (stat.size <= offset) {
+        fs.closeSync(fd);
+        return;
+      }
+      const readBuf = Buffer.alloc(stat.size - offset);
+      fs.readSync(fd, readBuf as any, 0, readBuf.length, offset);
+      offset = stat.size;
+      fs.closeSync(fd);
+      content = readBuf.toString('utf-8');
+    } catch {
+      return;
+    }
+
+    buffer += content;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        const level = entry.level ?? 'info';
+        const ts = entry.timestamp ?? '';
+        const msg = entry.message ?? '';
+        const meta =
+          entry.metadata && Object.keys(entry.metadata).length ? JSON.stringify(entry.metadata) : '';
+        const formatted = [`[BACKPORT-LIB]`, ts, `[${level}]`, msg, meta].filter(Boolean).join(' ');
+        if (level === 'error') {
+          core.error(formatted);
+        } else if (level === 'warn') {
+          core.warning(formatted);
+        } else {
+          core.info(formatted);
+        }
+      } catch {
+        core.info(`[BACKPORT-LIB] ${line}`);
+      }
+    }
+  }
+
+  const timer = setInterval(() => {
+    if (!stopped) flush();
+  }, intervalMs);
+
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+    flush();
+    if (buffer.trim()) {
+      core.info(`[BACKPORT-LIB] ${buffer}`);
+      buffer = '';
+    }
+  };
 }


### PR DESCRIPTION
Sometimes our backport actions take quite long (https://github.com/elastic/kibana/actions/runs/22185216934 - 54min), and we don't really have very good visibility on what's taking so long.

This pull request adds logging to the backport automation scripts to improve traceability and debugging of the on-merge workflow.

The most important changes are:

**Enhanced Logging for Workflow and Backport Process**
- Added `core.info` log statements throughout `on-merge/index.js` to document workflow initialization, configuration loading, PR processing, label adjustments, backport target resolution, debounce timing, PR updates, and the backport run itself. Also logs log file paths and backport run status for improved traceability. [[1]](diffhunk://#diff-c0e1f89cde3a0438903d416d0f585cf57b539bea63ea5b1d216ea5a3a6d5cb1fR59-R143) [[2]](diffhunk://#diff-c0e1f89cde3a0438903d416d0f585cf57b539bea63ea5b1d216ea5a3a6d5cb1fR153-R156)

**Detailed Logging in Backport Target Resolution**
- Updated `on-merge/backportTargets.ts` and its compiled JS to log the process of resolving backport targets, including input labels, label matching, branch mapping, and final target selection. This makes it easier to understand why certain branches are chosen or skipped. [[1]](diffhunk://#diff-09e45622ac046fc1de8692094a328ccd0ba1a9644e0e92e526895a9e02f42275R19-R87) [[2]](diffhunk://#diff-b07f5c3088eb458c6b55897aac7c5804f5c131db8cfdea2707aa8d68d6b7a8b9R37-R89)

**Verbose Logging for GitHub API Operations**
- Modified `on-merge/github.ts` and its compiled JS to log every major GitHub API operation, such as fetching file content, adding/removing labels, creating comments, and updating pull requests. Each operation logs inputs, actions, and success confirmations for better observability. [[1]](diffhunk://#diff-213c18b18c2c19053271991722828297ef0516ffb2e1de8d147e6313b24071fcR29-R45) [[2]](diffhunk://#diff-213c18b18c2c19053271991722828297ef0516ffb2e1de8d147e6313b24071fcR57-R99) [[3]](diffhunk://#diff-a50e2902b4e2d54b56d0dad1539bbf92990906b508ff77458e2c4d1ca0578335R63-R101)

**Other Minor Improvements**
- Imported `os` and `path` in `on-merge/index.js` to support log file path generation for backport runs.

These changes collectively make the backport workflow much more transparent and easier to debug by providing granular logs at every important step.