### PR TITLE
update handlebars to 4.7.9 through an override field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4809,9 +4809,10 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -10572,7 +10573,7 @@
         "find-up": "^5.0.0",
         "graphql": "^16.8.0",
         "graphql-tag": "^2.12.6",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "inquirer": "^8.2.5",
         "lodash": "^4.17.23",
         "make-dir": "^3.1.0",
@@ -11968,9 +11969,9 @@
       }
     },
     "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -14188,7 +14189,7 @@
       "requires": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cookie": "^0.7.2",
     "cross-spawn": "^7.0.5",
     "diff": "^5.2.2",
+    "handlebars": "^4.7.9",
     "lodash": "^4.17.23",
     "nanoid": "^3.3.8",
     "serialize-javascript": "^6.0.2"


### PR DESCRIPTION
Fixes several vulnerabilities through https://github.com/handlebars-lang/handlebars.js/releases/tag/v4.7.9