### PR TITLE
Add assignees or reviewers from the source PR to bot backports

### DIFF
--- a/on-merge/github.js
+++ b/on-merge/github.js
@@ -90,6 +90,29 @@ class GithubWrapper {
         core.info(`[GH-API] Comment created successfully on issue #${issueNumber}`);
         return response.data;
     }
+    async getApprovers(pullNumber) {
+        var _a;
+        core.info(`[GH-API] Fetching reviews for PR #${pullNumber}`);
+        const response = await this.github.pulls.listReviews({
+            owner: this.owner,
+            repo: this.repo,
+            pull_number: pullNumber,
+        });
+        // Walk reviews chronologically and keep the latest state per reviewer,
+        // so a dismissed/changed approval doesn't count.
+        const latestStateByUser = new Map();
+        for (const review of response.data) {
+            const login = (_a = review.user) === null || _a === void 0 ? void 0 : _a.login;
+            if (!login || !review.state)
+                continue;
+            latestStateByUser.set(login, review.state);
+        }
+        const approvers = Array.from(latestStateByUser.entries())
+            .filter(([, state]) => state === 'APPROVED')
+            .map(([login]) => login);
+        core.info(`[GH-API] Found ${approvers.length} approver(s) for PR #${pullNumber}: ${approvers.join(', ')}`);
+        return approvers;
+    }
     async updatePullRequest(number, updateFields) {
         core.info(`[GH-API] Updating PR #${number}, body length: ${updateFields.body.length} chars`);
         const response = await this.github.pulls.update({

--- a/on-merge/github.ts
+++ b/on-merge/github.ts
@@ -88,6 +88,32 @@ export class GithubWrapper {
     return response.data;
   }
 
+  async getApprovers(pullNumber: number): Promise<string[]> {
+    core.info(`[GH-API] Fetching reviews for PR #${pullNumber}`);
+    const response = await this.github.pulls.listReviews({
+      owner: this.owner,
+      repo: this.repo,
+      pull_number: pullNumber,
+    });
+
+    // Walk reviews chronologically and keep the latest state per reviewer,
+    // so a dismissed/changed approval doesn't count.
+    const latestStateByUser = new Map<string, string>();
+    for (const review of response.data) {
+      const login = review.user?.login;
+      if (!login || !review.state) continue;
+      latestStateByUser.set(login, review.state);
+    }
+
+    const approvers = Array.from(latestStateByUser.entries())
+      .filter(([, state]) => state === 'APPROVED')
+      .map(([login]) => login);
+    core.info(
+      `[GH-API] Found ${approvers.length} approver(s) for PR #${pullNumber}: ${approvers.join(', ')}`,
+    );
+    return approvers;
+  }
+
   async updatePullRequest(number: number, updateFields: { body: string }) {
     core.info(`[GH-API] Updating PR #${number}, body length: ${updateFields.body.length} chars`);
     const response = await this.github.pulls.update({

--- a/on-merge/index.js
+++ b/on-merge/index.js
@@ -129,7 +129,8 @@ async function runOnMergeAction() {
         core.info('[PR-UPDATE] PR updated successfully');
         // Start backport for the calculated targets
         core.info(`[BACKPORT-RUN] Initiating backport for PR #${pullRequest.number} to ${targets.length} target(s)`);
-        core.info(`[BACKPORT-RUN] Backport config: assignees=[${pullRequest.user.login}], autoMerge=true, autoMergeMethod=squash`);
+        const assignees = await resolveBackportAssignees(githubWrapper, pullRequest);
+        core.info(`[BACKPORT-RUN] Backport config: assignees=[${assignees.join(', ')}], autoMerge=true, autoMergeMethod=squash`);
         const logFilePath = path.join(os.tmpdir(), `backport-${pullRequest.number}.log`);
         core.info(`[BACKPORT-RUN] Log file: ${logFilePath}`);
         const stopTailing = (0, util_1.tailFileToActions)({ filePath: logFilePath, logger: core });
@@ -142,7 +143,7 @@ async function runOnMergeAction() {
                     interactive: false,
                     logFilePath,
                     pullNumber: pullRequest.number,
-                    assignees: [pullRequest.user.login],
+                    assignees,
                     autoMerge: true,
                     autoMergeMethod: 'squash',
                     targetBranches: targets,
@@ -205,6 +206,29 @@ async function runOnMergeAction() {
     else {
         core.info(`[EXIT] PR base is not main (${pullRequest.base.ref}) and no backport label present. Nothing to do.`);
     }
+}
+async function resolveBackportAssignees(githubWrapper, pullRequest) {
+    var _a;
+    const author = pullRequest.user.login;
+    if (!isBotUser(author)) {
+        return [author];
+    }
+    core.info(`[ASSIGNEES] PR author "${author}" is a bot, looking for fallback assignees`);
+    const prAssignees = ((_a = pullRequest.assignees) !== null && _a !== void 0 ? _a : []).map((u) => u.login).filter((login) => !isBotUser(login));
+    if (prAssignees.length) {
+        core.info(`[ASSIGNEES] Using PR assignees as fallback: ${prAssignees.join(', ')}`);
+        return prAssignees;
+    }
+    const approvers = (await githubWrapper.getApprovers(pullRequest.number)).filter((login) => !isBotUser(login));
+    if (approvers.length) {
+        core.info(`[ASSIGNEES] Using PR approvers as fallback: ${approvers.join(', ')}`);
+        return approvers;
+    }
+    core.warning(`[ASSIGNEES] No fallback assignees found for bot-authored PR #${pullRequest.number}, falling back to author`);
+    return [author];
+}
+function isBotUser(login) {
+    return login === 'Copilot' || login.includes('[bot]');
 }
 function isPRBackportToCurrentRelease(pullRequest, currentLabel) {
     return ((0, util_1.getVersionLabels)(pullRequest.labels).length === 1 &&

--- a/on-merge/index.ts
+++ b/on-merge/index.ts
@@ -145,8 +145,11 @@ async function runOnMergeAction() {
     core.info(
       `[BACKPORT-RUN] Initiating backport for PR #${pullRequest.number} to ${targets.length} target(s)`,
     );
+    const assignees = await resolveBackportAssignees(githubWrapper, pullRequest);
     core.info(
-      `[BACKPORT-RUN] Backport config: assignees=[${pullRequest.user.login}], autoMerge=true, autoMergeMethod=squash`,
+      `[BACKPORT-RUN] Backport config: assignees=[${assignees.join(
+        ', ',
+      )}], autoMerge=true, autoMergeMethod=squash`,
     );
     const logFilePath = path.join(os.tmpdir(), `backport-${pullRequest.number}.log`);
     core.info(`[BACKPORT-RUN] Log file: ${logFilePath}`);
@@ -160,7 +163,7 @@ async function runOnMergeAction() {
           interactive: false,
           logFilePath,
           pullNumber: pullRequest.number,
-          assignees: [pullRequest.user.login],
+          assignees,
           autoMerge: true,
           autoMergeMethod: 'squash',
           targetBranches: targets,
@@ -229,6 +232,41 @@ async function runOnMergeAction() {
       `[EXIT] PR base is not main (${pullRequest.base.ref}) and no backport label present. Nothing to do.`,
     );
   }
+}
+
+async function resolveBackportAssignees(
+  githubWrapper: GithubWrapper,
+  pullRequest: PullRequestEvent['pull_request'],
+): Promise<string[]> {
+  const author = pullRequest.user.login;
+  if (!isBotUser(author)) {
+    return [author];
+  }
+
+  core.info(`[ASSIGNEES] PR author "${author}" is a bot, looking for fallback assignees`);
+
+  const prAssignees = (pullRequest.assignees ?? []).map((u) => u.login).filter((login) => !isBotUser(login));
+  if (prAssignees.length) {
+    core.info(`[ASSIGNEES] Using PR assignees as fallback: ${prAssignees.join(', ')}`);
+    return prAssignees;
+  }
+
+  const approvers = (await githubWrapper.getApprovers(pullRequest.number)).filter(
+    (login) => !isBotUser(login),
+  );
+  if (approvers.length) {
+    core.info(`[ASSIGNEES] Using PR approvers as fallback: ${approvers.join(', ')}`);
+    return approvers;
+  }
+
+  core.warning(
+    `[ASSIGNEES] No fallback assignees found for bot-authored PR #${pullRequest.number}, falling back to author`,
+  );
+  return [author];
+}
+
+function isBotUser(login: string): boolean {
+  return login === 'Copilot' || login.includes('[bot]');
 }
 
 function isPRBackportToCurrentRelease(pullRequest: { labels: { name: string }[] }, currentLabel: string) {


### PR DESCRIPTION
When backports are created from bot PRs, there are no assignees who can/should follow if the backports end up landing.

This PR tries to import assignees, then approvers as assignees to the backport PRs of machines, keeping humans in the loop.