### PR TITLE
Add new Appex board mappings 2516

### DIFF
--- a/github-projects/map-labels/mapping-sizes-and-impact-p2516.json
+++ b/github-projects/map-labels/mapping-sizes-and-impact-p2516.json
@@ -25,12 +25,24 @@
   },
   "loe:needs-research": null,
   "Team:DataDiscovery": {
-    "Team": "AppEx 2"
+    "Team": "Discover"
   },
   "Team:Visualizations": {
-    "Team": "AppEx 1"
+    "Team": "Dashboards"
   },
   "Team:Presentations": {
-    "Team": "AppEx 1"
+    "Team": "Dashboards"
   },
+  "Team:SharedUX": {
+    "Team": "Global UX"
+  },
+  "Team:EUI": {
+    "Team": "Global UX"
+  },
+  "Team:ML": {
+    "Team": "Search ML"
+  },
+  "Team:Search": {
+    "Team": "Search ML"
+  }
 }

--- a/github-projects/map-labels/mapping-sizes-and-impact-p2516.json
+++ b/github-projects/map-labels/mapping-sizes-and-impact-p2516.json
@@ -24,58 +24,13 @@
     }
   },
   "loe:needs-research": null,
-  "Feature:ES|QL": {
+  "Team:DataDiscovery": {
     "Team": "AppEx 2"
   },
-  "Feature:Alerting": {
-    "Team": "AppEx 2"
-  },
-  "Feature:Embeddables": {
+  "Team:Visualizations": {
     "Team": "AppEx 1"
   },
-  "Feature:FieldFormatters": {
-    "Team": "AppEx 2"
+  "Team:Presentations": {
+    "Team": "AppEx 1"
   },
-  "Feature:Data Views": {
-    "Team": "AppEx 2"
-  },
-  "Feature:BackgroundSearch": {
-    "Team": "AppEx 2"
-  },
-  "Feature:Search": {
-    "Team": "AppEx 2"
-  },
-  "Project:OneDiscover": {
-    "Project": "One Discover"
-  },
-  "Feature:UnifiedDocViewer": {
-    "Project": "Unified Doc Viewer"
-  },
-  "Feature:UnifiedDataTable": {
-    "Project": "Unified Data Table"
-  },
-  "Feature:UnifiedFieldList": {
-    "Project": "Unified Field List"
-  },
-  "Feature:UnifiedHistogram": {
-    "Project": "Unified Histogram"
-  },
-  "Project:Accessibility": {
-    "Project": "A11y"
-  },
-  "performance": {
-    "Project": "Performance"
-  },
-  "technical debt": {
-    "Project": "Tech Debt"
-  },
-  "test-failure-flaky": {
-    "Project": "Test Failures"
-  },
-  "failed-test": {
-    "Project": "Test Failures"
-  },
-  "skipped-test": {
-    "Project": "Test Failures"
-  }
 }

--- a/github-projects/map-labels/mapping-sizes-and-impact-p2516.json
+++ b/github-projects/map-labels/mapping-sizes-and-impact-p2516.json
@@ -1,0 +1,81 @@
+{
+  "loe:small": {
+    "Size": {
+      "value": "🐇 Small (2-3d)",
+      "override": true
+    }
+  },
+  "loe:medium": {
+    "Size": {
+      "value": "🐄 Medium (1-2w)",
+      "override": true
+    }
+  },
+  "loe:large": {
+    "Size": {
+      "value": "🐙 Large (2-4w)",
+      "override": true
+    }
+  },
+  "loe:x-large": {
+    "Size": {
+      "value": "🐳 X-Large (>4w)",
+      "override": true
+    }
+  },
+  "loe:needs-research": null,
+  "Feature:ES|QL": {
+    "Team": "AppEx 2"
+  },
+  "Feature:Alerting": {
+    "Team": "AppEx 2"
+  },
+  "Feature:Embeddables": {
+    "Team": "AppEx 1"
+  },
+  "Feature:FieldFormatters": {
+    "Team": "AppEx 2"
+  },
+  "Feature:Data Views": {
+    "Team": "AppEx 2"
+  },
+  "Feature:BackgroundSearch": {
+    "Team": "AppEx 2"
+  },
+  "Feature:Search": {
+    "Team": "AppEx 2"
+  },
+  "Project:OneDiscover": {
+    "Project": "One Discover"
+  },
+  "Feature:UnifiedDocViewer": {
+    "Project": "Unified Doc Viewer"
+  },
+  "Feature:UnifiedDataTable": {
+    "Project": "Unified Data Table"
+  },
+  "Feature:UnifiedFieldList": {
+    "Project": "Unified Field List"
+  },
+  "Feature:UnifiedHistogram": {
+    "Project": "Unified Histogram"
+  },
+  "Project:Accessibility": {
+    "Project": "A11y"
+  },
+  "performance": {
+    "Project": "Performance"
+  },
+  "technical debt": {
+    "Project": "Tech Debt"
+  },
+  "test-failure-flaky": {
+    "Project": "Test Failures"
+  },
+  "failed-test": {
+    "Project": "Test Failures"
+  },
+  "skipped-test": {
+    "Project": "Test Failures"
+  }
+}


### PR DESCRIPTION
This pull request introduces a new mapping configuration for project labels to standardized size and team values. The main changes involve defining how specific labels correspond to size estimates and team assignments.

Board:
https://github.com/orgs/elastic/projects/2516/views/4?sliceBy%5Bvalue%5D=Discover%2FData+Home

* Label-to-Size Mappings
* Label-to-Team Mappings

Let's start with those, and add more later on 